### PR TITLE
add to_seq and of_seq

### DIFF
--- a/ptset.ml
+++ b/ptset.ml
@@ -123,6 +123,8 @@ let add k t =
 
 let of_list = List.fold_left (fun s x -> add x s) empty
 
+let of_seq seq = Seq.fold_left (fun s x -> add x s) empty seq
+
 (*s The code to remove an element is basically similar to the code of
     insertion. But since we have to maintain the invariant that both
     subtrees of a [Branch] node are non-empty, we use here the
@@ -439,6 +441,8 @@ module Big = struct
 
   let of_list = List.fold_left (fun s x -> add x s) empty
 
+  let of_seq seq = Seq.fold_left (fun s x -> add x s) empty seq
+
   let remove k t =
     let rec rmv = function
       | Empty -> Empty
@@ -644,6 +648,13 @@ module BigPos = struct
 
   (* let to_list = elements *)
 
+  let to_seq s =
+    let rec elements_aux acc s () = match s with
+      | Empty -> Seq.Nil
+      | Leaf k -> Seq.Cons (k, acc)
+      | Branch (_,_,l,r) -> elements_aux (elements_aux acc r) l ()
+    in
+    elements_aux Seq.empty s
 end
 
 (*s EXPERIMENT: Big-endian Patricia trees with swapped bit sign *)

--- a/ptset.mli
+++ b/ptset.mli
@@ -61,6 +61,7 @@ val choose_opt: t -> elt option
 val find: elt -> t -> elt
 val find_opt: elt -> t -> elt option
 val of_list : elt list -> t
+val of_seq : elt Seq.t -> t
 val map: (elt -> elt) -> t -> t
 val partition: (elt -> bool) -> t -> t * t
 val split: elt -> t -> t * bool * t
@@ -100,6 +101,7 @@ module Big : sig
   val find: elt -> t -> elt
   val find_opt: elt -> t -> elt option
   val of_list : elt list -> t
+  val of_seq : elt Seq.t -> t
   val map: (elt -> elt) -> t -> t
   val partition: (elt -> bool) -> t -> t * t
   val split: elt -> t -> t * bool * t
@@ -140,6 +142,7 @@ module BigPos : sig
   val find: elt -> t -> elt
   val find_opt: elt -> t -> elt option
   val of_list : elt list -> t
+  val of_seq : elt Seq.t -> t
   val map: (elt -> elt) -> t -> t
   val partition: (elt -> bool) -> t -> t * t
   val split: elt -> t -> t * bool * t
@@ -148,4 +151,5 @@ module BigPos : sig
   val max_elt: t -> elt
   val max_elt_opt: t -> elt option
   val elements: t -> elt list
+  val to_seq: t -> elt Seq.t
 end


### PR DESCRIPTION
This PR adds `of_seq`, and also `to_seq` when `to_list` was already provided.